### PR TITLE
Submit to Carpentry as a self-organized workshop

### DIFF
--- a/workshop_operations/checklists.md
+++ b/workshop_operations/checklists.md
@@ -35,6 +35,7 @@ Table of Contents
 * send a call for co-instructors and helpers to the ``organizers @ swcarpentry dot uio dot no`` list and ask them to sign up in the spreadsheet
 * NOTE: a full-day workshop can only be confirmed if at least two instructors have signed up in the spreadsheet
 * generate the workshop website at uio-carpentry dot github dot com using the template from https://github.com/swcarpentry/workshop-template. NOTE: make sure that you are a member of the [uio-carpentry github organisation](https://github.com/orgs/uio-carpentry/people), and *choose this organisation as owner* for the workshop repository when you import the template
+* Submit a self-organized workshop to Carpentry central from [this form](https://amy.carpentries.org/forms/self-organised/). The Regional Coordinator will then register instructor information at the Carpentry's sytem as well as make workshop information visible on Carpentry website.  
 * if you are not yet a member of [uio-carpentry on github](https://github.com/orgs/uio-carpentry/people), create a GitHub profile and send an email to ``organizers @ swcarpentry dot uio dot no`` with your GitHub username and ask to be added.
 * organise pre-workshop meeting with the other instructors and the helpers to go through lesson materials etc.
 


### PR DESCRIPTION
To record self-organized workshops at the Carpentry central, they need to be registered by using a form.