### PR TITLE
Added checkbox for workshop attendance list

### DIFF
--- a/workshop_operations/onboarding-checklist.md
+++ b/workshop_operations/onboarding-checklist.md
@@ -75,6 +75,7 @@ Please make sure that you and the learners wipe facilities and areas they used w
   - [ ] Make sure the equipment you are planning to use works in the seminar room
   - [ ] Explain the Code of Conduct in the beginning of the workshop
   - [ ] Do a short security briefing in the beginning of the workshop
+  - [ ] Take attendance using the [workshops attendance list](/workshops_attendance_list.pdf) provided in the equipment box
   - [ ] Ask the participants to answer post-workshop survey linked from the workshop website at the end of the workshop
   - [ ] Leave the seminar room clean and orderly; make sure that no equipment is left, windows are closed and lights are off
 


### PR DESCRIPTION
I updated the old sign-up sheet to an attendance list. We want to take actual attendance and know who's there and who skipped the workshop without telling us as a measure to reduce no-shows.
I added a short statement in the attendance list about what we are using the personal data (names) for.

We need to print a couple of these lists and put them in the equipment box in NHA209