### PR TITLE
fix the link to "website"

### DIFF
--- a/workshop_operations/post_workshop_email_template.md
+++ b/workshop_operations/post_workshop_email_template.md
@@ -19,7 +19,7 @@ FIXME add link
 
 - get involved! The Carpentry effort at UiO is a volunteer project; if you'd like to help us, let us know by sending an email to carpadmin@carpentry.uio.no
 
-Note that information about upcoming workshops can be found on our [website](uio.no/carpentry) and the [University of Oslo Library's course catalogue](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/index.html).
+Note that information about upcoming workshops can be found on our [website](https://uio.no/carpentry) and the [University of Oslo Library's course catalogue](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/index.html).
 
 We hope to see you again on another occasion. On behalf of the workshop instructors and helpers,
 


### PR DESCRIPTION
it seems "uio.no/carpentry" does not work if it is without "https://", so I inserted it. However, the linked page shows "non-Carpentry" workshops/courses as well. Is this page fine?